### PR TITLE
feat(patch): Implement PATCH method

### DIFF
--- a/src/main/restql/core/statement/core.clj
+++ b/src/main/restql/core/statement/core.clj
@@ -17,13 +17,13 @@
 (defn- is-post-or-put-or-patch? [statement]
   (or (= :post (:method statement)) (= :put (:method statement)) (= :patch (:method statement))))
 
-(defn- params-with-body [mappings statement params]
+(defn- default-modifier-params [mappings statement params]
   (let [query-params (url-utils/filter-explicit-query-params (url-utils/from-mappings mappings statement) params)
         body  (url-utils/dissoc-params (url-utils/from-mappings mappings statement) params)]
     (into (if-not (empty? query-params) (assoc? {} :query-params query-params) {})
           (if-not (empty? body) (assoc? {} :body body) {}))))
 
-(defn- default-params [mappings statement params]
+(defn- default-fetch-params [mappings statement params]
   (let [query-params (url-utils/dissoc-path-params (url-utils/from-mappings mappings statement) params)]
     (if-not (empty? query-params) (assoc? {} :query-params query-params) {})))
 
@@ -32,8 +32,8 @@
        (get :with)
        (as-> params 
              (if (is-post-or-put-or-patch? statement)
-               (params-with-body mappings statement params)
-               (default-params mappings statement params)))
+               (default-modifier-params mappings statement params)
+               (default-fetch-params mappings statement params)))
        (conj request)))
 
 (defn- add-metadata-from-statement-meta [statement]

--- a/src/main/restql/core/statement/core.clj
+++ b/src/main/restql/core/statement/core.clj
@@ -14,13 +14,13 @@
       (as-> url (assoc {} :url url))
       (conj request)))
 
-(defn- is-post-or-put? [statement]
-  (or (= :post (:method statement)) (= :put (:method statement))))
+(defn- is-post-or-put-or-patch? [statement]
+  (or (= :post (:method statement)) (= :put (:method statement)) (= :patch (:method statement))))
 
 (defn- add-query-params [mappings statement request]
   (-> statement
       (get :with)
-      (as-> params (if (is-post-or-put? statement)
+      (as-> params (if (is-post-or-put-or-patch? statement)
                      (url-utils/filter-explicit-query-params (url-utils/from-mappings mappings statement) params)
                      (url-utils/dissoc-path-params (url-utils/from-mappings mappings statement) params)))
       (as-> params (if-not (empty? params) (assoc? {} :query-params params) {}))
@@ -29,7 +29,7 @@
 (defn- add-body-params [mappings statement request]
   (-> statement
       (get :with)
-      (as-> params (if (is-post-or-put? statement)
+      (as-> params (if (is-post-or-put-or-patch? statement)
                      (url-utils/dissoc-params (url-utils/from-mappings mappings statement) params)
                      (identity {})))
       (as-> params (if-not (empty? params) (assoc? {} :body params) {}))

--- a/src/main/restql/parser/producer.clj
+++ b/src/main/restql/parser/producer.clj
@@ -215,6 +215,7 @@
       (= "to" content-str) ":post"
       (= "into" content-str) ":put"
       (= "delete" content-str) ":delete"
+      (= "update" content-str) ":patch"
       :else ":get")))
 
 (defn produce

--- a/src/resources/grammar.ebnf
+++ b/src/resources/grammar.ebnf
@@ -165,7 +165,7 @@ IgnoreErrorsFlag =
   <"use">;
 
 <KW_METHOD> =
-  ("from" | "to" | "into" | "delete");
+  ("from" | "to" | "into" | "delete" | "update");
 
 HttpMethod =
   KW_METHOD;

--- a/test/integration/restql/restql_test.clj
+++ b/test/integration/restql/restql_test.clj
@@ -275,6 +275,15 @@
       (let [result (execute-query uri "to villain with id = 1, name = \"Jocker\"")]
         (is (= 200 (get-in result [:villain :details :status])))))))
 
+(deftest execute-query-patch
+  (testing "Execute patch with simple body"
+    (with-routes!
+      {(fn [request]
+         (and (= (:path request) "/villain/1")
+              (= (:method request) "PATCH"))) (hero-route)}
+      (let [result (execute-query uri "update villain with id = 1, name = \"Thanos\"")]
+        (is (= 200 (get-in result [:villain :details :status])))))))
+
 (deftest request-with-float-param
   (testing "In-query float param should not be considered a chained call"
     (with-routes!

--- a/test/unit/restql/parser/core_test.clj
+++ b/test/unit/restql/parser/core_test.clj
@@ -24,6 +24,10 @@
     (is (= (parse-query "delete heroes")
            [:heroes {:from :heroes :method :delete}])))
 
+  (testing "Testing patch method"
+    (is (= (parse-query "update heroes")
+           [:heroes {:from :heroes :method :patch}])))
+
   (testing "Testing simple query params a use clause"
     (is (= (parse-query "use cache-control = 900
                                       from heroes as hero")


### PR DESCRIPTION
Motivated by issue B2W-BIT/restQL-http/issues/117

Implemented PATCH HTTP method, which can be used with the tag `update` as in:

```
update users
  with
    id       = "12345"
    name = "John Doe"
```