### PR TITLE
fix(performance): execute all requests before extracting results

### DIFF
--- a/src/main/restql/core/runner/executor.clj
+++ b/src/main/restql/core/runner/executor.clj
@@ -13,7 +13,7 @@
 (defn- query-and-join [requests query-opts]
   (let [operation (if (sequential? (first requests)) query-and-join make-request)]
     (->> requests
-         (map #(operation % query-opts))
+         (mapv #(operation % query-opts))
          (extract-result-keeping-channels-order))))
 
 (defn- single-request-not-multiplexed? [requests]
@@ -24,8 +24,8 @@
 
 (defn do-request [statements exception-ch {:keys [_debugging] :as query-opts}]
   (try+
-    (if (single-request-not-multiplexed? statements)
-        (make-request (first statements) query-opts)
-        (query-and-join statements query-opts))
+   (if (single-request-not-multiplexed? statements)
+     (make-request (first statements) query-opts)
+     (query-and-join statements query-opts))
    (catch Object e
      (go (>! exception-ch e)))))


### PR DESCRIPTION
After further investigation, it was discovered that the [make-request operation](https://github.com/B2W-BIT/restQL-clojure/blob/e34461bb00f8759903a55f3358ce8475ce5dcff7/src/main/restql/core/runner/executor.clj#L14) inside the [query-and-join method](https://github.com/B2W-BIT/restQL-clojure/blob/e34461bb00f8759903a55f3358ce8475ce5dcff7/src/main/restql/core/runner/executor.clj#L13) has being executed sequentially because of the wrong combination of a lazy sequence ([returned by map](https://github.com/B2W-BIT/restQL-clojure/blob/e34461bb00f8759903a55f3358ce8475ce5dcff7/src/main/restql/core/runner/executor.clj#L16)) and a [go-loop](https://github.com/B2W-BIT/restQL-clojure/blob/e34461bb00f8759903a55f3358ce8475ce5dcff7/src/main/restql/core/runner/executor.clj#L7), that made that only one take (one call for execution in the lazy sequence) was executed at every revolution.